### PR TITLE
Remove members from roster - admin feature

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,8 +1,9 @@
 class MembersController < ApplicationController
-    # before_action :set_announcement, only: %i[ show edit update destroy ]
     before_action :authenticate_user!
     # GET /members
     def index
       @users = User.all
+      puts(@users)
     end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,5 +52,9 @@ class User < ApplicationRecord
     result
   end
 
-
+  def self.update_active_status(user)
+    user.active = false
+    user.save
+    puts(user)
+  end
 end

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -47,6 +47,7 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
+      <% if user.active %>
         <td colspan="3"><%= user.uin %></td>
         <td colspan="3"><%= user.firstname %></td>
         <td colspan="3"><%= user.lastname %></td>
@@ -56,12 +57,13 @@
         <td colspan="3"><%= user.major %></td>
         <% if current_user && current_user.admin %>
           <% if current_user != user %>
-            <td><%= link_to 'Remove', members_delete_path_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td><%= link_to 'Remove', User.update_active_status(user) %></td>
           <% end %>
           <% if current_user == user %>
             <td></td>
           <% end %>
         <% end %>
+      <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,7 @@ Rails.application.routes.draw do
   resources :profile
   resources :merches
 
-  put 'profile_page' => 'profile_page#edit', :as => 'profile_page_update_path'
   get 'members' => 'members#index', :as => 'members_path'
-  delete 'members' => 'members#destroy', :as => 'members_delete_path'
-
 
   #root 'ks_hubs#index'
   # or details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20221114044109_add_active_status_to_user.rb
+++ b/db/migrate/20221114044109_add_active_status_to_user.rb
@@ -1,0 +1,5 @@
+class AddActiveStatusToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_08_163606) do
+ActiveRecord::Schema.define(version: 2022_11_14_044109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,10 @@ ActiveRecord::Schema.define(version: 2022_11_08_163606) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "full_name"
+    t.string "uid"
+    t.string "avatar_url"
+    t.string "provider"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -66,10 +70,7 @@ ActiveRecord::Schema.define(version: 2022_11_08_163606) do
     t.string "pledgeclass"
     t.string "major"
     t.string "username"
-    t.string "full_name"
-    t.string "uid"
-    t.string "avatar_url"
-    t.string "provider"
+    t.boolean "active", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
A boolean attribute "active" has been added to the user data model. Removing a member from the roster page simply changes this status to inactive so that user will not render on the member page. The remove feature does not remove a user from the database, these inactive users still have access to the application.